### PR TITLE
Update converters.py

### DIFF
--- a/livebridge_scribblelive/converters.py
+++ b/livebridge_scribblelive/converters.py
@@ -152,6 +152,7 @@ class LiveblogScribbleliveConverter(BaseConverter):
             content = meta["html"]
         else:
             pass # positive list
+        # TODO: [\r\n]+ -> " ", strip ^[\r\n ]+ and [\r\n ]+$ 
 
         # add extra text
         if meta.get("title"):


### PR DESCRIPTION
Embed codes can contain characters like \r \n that will be converted into br-tags by Scribblelive, breaking things